### PR TITLE
Add database reset endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask
 from gcp_microservice_utils import setup_apigateway, setup_cloud_logging, setup_cloud_trace
 
-from blueprints import BlueprintBackup, BlueprintHealth
+from blueprints import BlueprintBackup, BlueprintHealth, BlueprintReset
 from containers import Container
 
 
@@ -33,5 +33,6 @@ def create_app() -> FlaskMicroservice:
 
     app.register_blueprint(BlueprintBackup)
     app.register_blueprint(BlueprintHealth)
+    app.register_blueprint(BlueprintReset)
 
     return app

--- a/blueprints/__init__.py
+++ b/blueprints/__init__.py
@@ -2,5 +2,6 @@
 
 from .backup import blp as BlueprintBackup
 from .health import blp as BlueprintHealth
+from .reset import blp as BlueprintReset
 
-__all__ = ['BlueprintBackup', 'BlueprintHealth']
+__all__ = ['BlueprintBackup', 'BlueprintHealth', 'BlueprintReset']

--- a/blueprints/reset.py
+++ b/blueprints/reset.py
@@ -1,0 +1,32 @@
+from dependency_injector.wiring import Provide, inject
+from flask import Blueprint, Response, request
+from flask.views import MethodView
+
+import demo
+from containers import Container
+from repositories import IncidentRepository
+
+from .util import class_route, json_response
+
+blp = Blueprint('Reset database', __name__)
+
+
+@class_route(blp, '/api/v1/reset/incidentmodify')
+class ResetDB(MethodView):
+    init_every_request = False
+
+    @inject
+    def post(
+        self,
+        incident_repo: IncidentRepository = Provide[Container.incident_repo],
+    ) -> Response:
+        incident_repo.delete_all()
+
+        if request.args.get('demo', 'false') == 'true':
+            for incident in demo.incidents:
+                incident_repo.create(incident)
+
+                for entry in demo.history[incident.id]:
+                    incident_repo.append_history_entry(entry)
+
+        return json_response({'status': 'Ok'}, 200)

--- a/containers.py
+++ b/containers.py
@@ -2,9 +2,13 @@ from dependency_injector import providers
 from dependency_injector.containers import DeclarativeContainer, WiringConfiguration
 from gcp_microservice_utils import access_token_provider
 
+from repositories.firestore import FirestoreIncidentRepository
+
 
 class Container(DeclarativeContainer):
     wiring_config = WiringConfiguration(packages=['blueprints'])
     config = providers.Configuration()
 
     access_token = providers.Callable(access_token_provider)
+
+    incident_repo = providers.ThreadSafeSingleton(FirestoreIncidentRepository, database=config.firestore.database)

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,0 +1,3 @@
+from .data import history, incidents
+
+__all__ = ['history', 'incidents']

--- a/demo/data.py
+++ b/demo/data.py
@@ -1,0 +1,105 @@
+from datetime import UTC, datetime
+
+from models import Action, Channel, HistoryEntry, Incident
+
+CLIENT_ID_GIGATEL = '9a652818-342e-4771-84cf-39c20a29264d'
+AGENT_ID_GIGATEL_JULIAN = '0abad006-921c-4e09-b2a6-10713b71571f'
+USER_ID_GIGATEL_MARIA = 'b713f559-cae5-4db3-992a-d3553fb25000'
+
+incident1 = Incident(
+    id='36e3344d-aa5b-4c5a-88ef-a7eb8abe27d8',
+    client_id=CLIENT_ID_GIGATEL,
+    name='Cobro incorrecto',
+    channel=Channel.WEB,
+    reported_by=USER_ID_GIGATEL_MARIA,
+    created_by=AGENT_ID_GIGATEL_JULIAN,
+    assigned_to=AGENT_ID_GIGATEL_JULIAN,
+)
+
+incident1_history = [
+    HistoryEntry(
+        incident_id=incident1.id,
+        client_id=CLIENT_ID_GIGATEL,
+        date=datetime(2024, 10, 18, 14, 26, 22, tzinfo=UTC),
+        action=Action.CREATED,
+        description=(
+            'He recibido mi factura de septiembre y aparece un cobro adicional por un servicio que no contraté. '
+            'El servicio en cuestión se llama "Asistencia Técnica Premium", pero yo nunca solicité ni autoricé este servicio. '
+            'Me di cuenta del cobro hoy, 10 de septiembre, al revisar el detalle de la factura. '
+            'Solicito que se revise mi cuenta y se realice el ajuste correspondiente en el menor tiempo posible.'
+        ),
+    ),
+    HistoryEntry(
+        incident_id=incident1.id,
+        client_id=CLIENT_ID_GIGATEL,
+        date=datetime(2024, 10, 18, 17, 31, 57, tzinfo=UTC),
+        action=Action.CLOSED,
+        description='Se hizó el ajuste en la tarjeta registrada para los pagos.',
+    ),
+]
+
+incident2 = Incident(
+    id='eccc588b-df31-4105-9940-86937059aff8',
+    client_id=CLIENT_ID_GIGATEL,
+    name='Internet no funciona',
+    channel=Channel.MOBILE,
+    reported_by=USER_ID_GIGATEL_MARIA,
+    created_by=USER_ID_GIGATEL_MARIA,
+    assigned_to=AGENT_ID_GIGATEL_JULIAN,
+)
+
+incident2_history = [
+    HistoryEntry(
+        incident_id=incident2.id,
+        client_id=CLIENT_ID_GIGATEL,
+        date=datetime(2024, 10, 20, 14, 26, 22, tzinfo=UTC),
+        action=Action.CREATED,
+        description=(
+            'No tengo acceso a Internet en mi hogar. El módem está encendido, pero no hay conexión. '
+            'He reiniciado el equipo varias veces y verificado que el servicio esté activo en mi cuenta, '
+            'pero el problema persiste. Solicito una revisión urgente del servicio.'
+        ),
+    ),
+    HistoryEntry(
+        incident_id=incident2.id,
+        client_id=CLIENT_ID_GIGATEL,
+        date=datetime(2024, 10, 21, 8, 11, 41, tzinfo=UTC),
+        action=Action.ESCALATED,
+        description=(
+            'Se ha llamado al cliente para verificar si pudo solucionar el problema con las recomendaciones '
+            'planteadas por la IA, pero comenta seguir con el problema, por lo cuál se le enviará un técnico '
+            'en un plazo de 2 días.'
+        ),
+    ),
+]
+
+incident3 = Incident(
+    id='8b51a60c-07d3-4ed3-85b9-352ded0abec5',
+    client_id=CLIENT_ID_GIGATEL,
+    name='Fallo servicios',
+    channel=Channel.EMAIL,
+    reported_by=USER_ID_GIGATEL_MARIA,
+    created_by=USER_ID_GIGATEL_MARIA,
+    assigned_to=AGENT_ID_GIGATEL_JULIAN,
+)
+
+incident3_history = [
+    HistoryEntry(
+        incident_id=incident3.id,
+        client_id=CLIENT_ID_GIGATEL,
+        date=datetime(2024, 10, 23, 19, 46, 40, tzinfo=UTC),
+        action=Action.CREATED,
+        description=(
+            'Desde hace 3 días no tengo acceso a los servicios de televisión, Internet y telefonía. '
+            'He revisado el estado de la conexión en el módem y en la caja de distribución, '
+            'pero no he encontrado ninguna anomalía. Solicito una revisión urgente del servicio.'
+        ),
+    ),
+]
+
+incidents = [incident1, incident2, incident3]
+history = {
+    incident1.id: incident1_history,
+    incident2.id: incident2_history,
+    incident3.id: incident3_history,
+}

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,6 @@
+from .action import Action
+from .channel import Channel
+from .history_entry import HistoryEntry
+from .incident import Incident
+
+__all__ = ['Action', 'Channel', 'HistoryEntry', 'Incident']

--- a/models/action.py
+++ b/models/action.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class Action(StrEnum):
+    CREATED = 'created'
+    ESCALATED = 'escalated'
+    CLOSED = 'closed'

--- a/models/channel.py
+++ b/models/channel.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class Channel(StrEnum):
+    WEB = 'web'
+    MOBILE = 'mobile'
+    EMAIL = 'email'

--- a/models/history_entry.py
+++ b/models/history_entry.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from .action import Action
+
+
+@dataclass
+class HistoryEntry:
+    incident_id: str
+    client_id: str
+    date: datetime
+    action: Action
+    description: str
+    seq: int | None = None  # Only set when reading from DB

--- a/models/incident.py
+++ b/models/incident.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+from .channel import Channel
+
+
+@dataclass
+class Incident:
+    id: str
+    client_id: str
+    name: str
+    channel: Channel
+    reported_by: str
+    created_by: str
+    assigned_to: str

--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -1,0 +1,3 @@
+from .incident import IncidentRepository
+
+__all__ = ['IncidentRepository']

--- a/repositories/firestore/__init__.py
+++ b/repositories/firestore/__init__.py
@@ -1,0 +1,3 @@
+from .incident import FirestoreIncidentRepository
+
+__all__ = ['FirestoreIncidentRepository']

--- a/repositories/firestore/incident.py
+++ b/repositories/firestore/incident.py
@@ -1,0 +1,50 @@
+import contextlib
+import logging
+from dataclasses import asdict
+from typing import cast
+
+from google.api_core.exceptions import AlreadyExists
+from google.cloud.firestore import Client as FirestoreClient  # type: ignore[import-untyped]
+from google.cloud.firestore_v1 import CollectionReference
+from google.cloud.firestore_v1.base_aggregation import AggregationResult
+
+from models import HistoryEntry, Incident
+from repositories import IncidentRepository
+
+
+class FirestoreIncidentRepository(IncidentRepository):
+    def __init__(self, database: str) -> None:
+        self.db = FirestoreClient(database=database)
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def create(self, incident: Incident) -> None:
+        incident_dict = asdict(incident)
+        del incident_dict['id']
+        del incident_dict['client_id']
+
+        client_ref = self.db.collection('clients').document(incident.client_id)
+        with contextlib.suppress(AlreadyExists):
+            client_ref.create({})
+
+        incident_ref = cast(CollectionReference, client_ref.collection('incidents')).document(incident.id)
+        incident_ref.create(incident_dict)
+
+    def append_history_entry(self, entry: HistoryEntry) -> None:
+        history_dict = asdict(entry)
+        del history_dict['client_id']
+        del history_dict['incident_id']
+        del history_dict['seq']
+
+        if entry.seq is not None:
+            raise ValueError('seq must be None when appending history entry')
+
+        client_ref = self.db.collection('clients').document(entry.client_id)
+        incident_ref = cast(CollectionReference, client_ref.collection('incidents')).document(entry.incident_id)
+        history_ref = cast(CollectionReference, incident_ref.collection('history'))
+        next_seq = int(cast(AggregationResult, history_ref.count().get()[0][0]).value)  # type: ignore[no-untyped-call]
+        entry_ref = history_ref.document(str(next_seq))
+
+        entry_ref.create(history_dict)
+
+    def delete_all(self) -> None:
+        self.db.recursive_delete(self.db.collection('clients'))

--- a/repositories/incident.py
+++ b/repositories/incident.py
@@ -1,0 +1,12 @@
+from models import HistoryEntry, Incident
+
+
+class IncidentRepository:
+    def create(self, incident: Incident) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    def append_history_entry(self, entry: HistoryEntry) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    def delete_all(self) -> None:
+        raise NotImplementedError  # pragma: no cover

--- a/tests/blueprints/test_reset.py
+++ b/tests/blueprints/test_reset.py
@@ -1,0 +1,52 @@
+from typing import cast
+from unittest.mock import Mock
+
+from unittest_parametrize import ParametrizedTestCase, parametrize
+
+import demo
+from app import create_app
+from repositories import IncidentRepository
+
+
+class TestReset(ParametrizedTestCase):
+    API_ENDPOINT = '/api/v1/reset/incidentmodify'
+
+    def setUp(self) -> None:
+        self.app = create_app()
+        self.client = self.app.test_client()
+
+    def tearDown(self) -> None:
+        self.app.container.unwire()
+
+    @parametrize(
+        'arg,expected',
+        [
+            (None, False),
+            ('true', True),
+            ('false', False),
+            ('foo', False),
+        ],
+    )
+    def test_reset(self, arg: str | None, expected: bool) -> None:  # noqa: FBT001
+        incident_repo_mock = Mock(IncidentRepository)
+        call_order = []
+
+        cast(Mock, incident_repo_mock.delete_all).side_effect = lambda: call_order.append('delete_all')
+        cast(Mock, incident_repo_mock.create).side_effect = lambda _x: call_order.append('create')
+        cast(Mock, incident_repo_mock.append_history_entry).side_effect = lambda _x: call_order.append('append_history_entry')
+
+        with self.app.container.incident_repo.override(incident_repo_mock):
+            resp = self.client.post(self.API_ENDPOINT + (f'?demo={arg}' if arg is not None else ''))
+
+        cast(Mock, incident_repo_mock.delete_all).assert_called_once()
+
+        if expected:
+            expected_call_order = ['delete_all']
+
+            for incident in demo.incidents:
+                expected_call_order.append('create')
+                expected_call_order += ['append_history_entry'] * len(demo.history[incident.id])
+
+            self.assertEqual(call_order, expected_call_order)
+
+        self.assertEqual(resp.status_code, 200)

--- a/tests/firestore/test_incident.py
+++ b/tests/firestore/test_incident.py
@@ -1,0 +1,130 @@
+import contextlib
+import os
+from dataclasses import asdict
+from datetime import UTC
+from typing import cast
+from unittest import skipUnless
+
+import requests
+from faker import Faker
+from google.api_core.exceptions import AlreadyExists
+from google.cloud.firestore import Client as FirestoreClient  # type: ignore[import-untyped]
+from google.cloud.firestore_v1 import CollectionReference
+from unittest_parametrize import ParametrizedTestCase
+
+from models import Action, Channel, HistoryEntry, Incident
+from repositories.firestore import FirestoreIncidentRepository
+
+FIRESTORE_DATABASE = '(default)'
+
+
+@skipUnless('FIRESTORE_EMULATOR_HOST' in os.environ, 'Firestore emulator not available')
+class TestClient(ParametrizedTestCase):
+    def setUp(self) -> None:
+        self.faker = Faker()
+
+        # Reset Firestore emulator before each test
+        requests.delete(
+            f'http://{os.environ["FIRESTORE_EMULATOR_HOST"]}/emulator/v1/projects/google-cloud-firestore-emulator/databases/{FIRESTORE_DATABASE}/documents',
+            timeout=5,
+        )
+
+        self.repo = FirestoreIncidentRepository(FIRESTORE_DATABASE)
+        self.client = FirestoreClient(database=FIRESTORE_DATABASE)
+
+    def create_random_incident(self, *, client_id: str | None = None) -> Incident:
+        return Incident(
+            id=cast(str, self.faker.uuid4()),
+            client_id=client_id or cast(str, self.faker.uuid4()),
+            name=self.faker.sentence(3),
+            channel=self.faker.random_element(list(Channel)),
+            reported_by=cast(str, self.faker.uuid4()),
+            created_by=cast(str, self.faker.uuid4()),
+            assigned_to=cast(str, self.faker.uuid4()),
+        )
+
+    def create_random_history_entry(self, *, client_id: str | None = None, incident_id: str | None = None) -> HistoryEntry:
+        return HistoryEntry(
+            incident_id=incident_id or cast(str, self.faker.uuid4()),
+            client_id=client_id or cast(str, self.faker.uuid4()),
+            date=self.faker.past_datetime(tzinfo=UTC),
+            action=self.faker.random_element(list(Action)),
+            description=self.faker.text(),
+        )
+
+    def add_random_incidents(self, n: int) -> list[Incident]:
+        incidents: list[Incident] = []
+
+        # Add n incidents to Firestore
+        for _ in range(n):
+            incident = self.create_random_incident()
+
+            incidents.append(incident)
+            incident_dict = asdict(incident)
+            del incident_dict['id']
+            del incident_dict['client_id']
+
+            client_ref = self.client.collection('clients').document(incident.client_id)
+            with contextlib.suppress(AlreadyExists):
+                client_ref.create({})
+
+            incident_ref = cast(CollectionReference, client_ref.collection('incidents')).document(incident.id)
+            incident_ref.create(incident_dict)
+
+        return incidents
+
+    def test_create(self) -> None:
+        incident = self.create_random_incident()
+
+        self.repo.create(incident)
+
+        client_ref = self.client.collection('clients').document(incident.client_id)
+        incident_ref = cast(CollectionReference, client_ref.collection('incidents')).document(incident.id)
+        doc = incident_ref.get()
+
+        self.assertTrue(doc.exists)
+        incident_dict = asdict(incident)
+        del incident_dict['id']
+        del incident_dict['client_id']
+        self.assertEqual(doc.to_dict(), incident_dict)
+
+    def test_append_history_entries(self) -> None:
+        client_id = cast(str, self.faker.uuid4())
+        incident_id = cast(str, self.faker.uuid4())
+        entries = [self.create_random_history_entry(client_id=client_id, incident_id=incident_id) for _ in range(5)]
+
+        for entry in entries:
+            self.repo.append_history_entry(entry)
+
+        for idx, entry in enumerate(entries):
+            client_ref = self.client.collection('clients').document(entry.client_id)
+            incident_ref = cast(CollectionReference, client_ref.collection('incidents')).document(entry.incident_id)
+            history_ref = cast(CollectionReference, incident_ref.collection('history'))
+            doc = history_ref.document(str(idx)).get()
+
+            self.assertTrue(doc.exists)
+            entry_dict = asdict(entry)
+            del entry_dict['client_id']
+            del entry_dict['incident_id']
+            del entry_dict['seq']
+            entry_db = doc.to_dict()
+            self.assertEqual(entry_db, entry_dict)
+
+    def test_append_history_valueerror(self) -> None:
+        entry = self.create_random_history_entry()
+        entry.seq = 1
+
+        with self.assertRaises(ValueError):
+            self.repo.append_history_entry(entry)
+
+    def test_delete_all(self) -> None:
+        incidents = self.add_random_incidents(5)
+
+        self.repo.delete_all()
+
+        for incident in incidents:
+            client_ref = self.client.collection('clients').document(incident.client_id)
+            incident_ref = cast(CollectionReference, client_ref.collection('incidents')).document(incident.id)
+            doc = incident_ref.get()
+
+            self.assertFalse(doc.exists)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new reset functionality for incidents, accessible via the `/api/v1/reset/incidentmodify` endpoint.
	- Added demo incident data for testing purposes, including predefined incidents and their histories.

- **Bug Fixes**
	- Enhanced error handling in the incident reset process.

- **Tests**
	- Added comprehensive test suites for the new reset functionality and Firestore incident repository, ensuring robust validation of features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->