### PR TITLE
Endpoint único de registro de incidencias

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask
 from gcp_microservice_utils import setup_apigateway, setup_cloud_logging, setup_cloud_trace
 
-from blueprints import BlueprintBackup, BlueprintHealth, BlueprintReset, BlueprintIncident
+from blueprints import BlueprintBackup, BlueprintHealth, BlueprintIncident, BlueprintReset
 from containers import Container
 
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask
 from gcp_microservice_utils import setup_apigateway, setup_cloud_logging, setup_cloud_trace
 
-from blueprints import BlueprintBackup, BlueprintHealth, BlueprintReset
+from blueprints import BlueprintBackup, BlueprintHealth, BlueprintReset, BlueprintIncident
 from containers import Container
 
 
@@ -34,5 +34,6 @@ def create_app() -> FlaskMicroservice:
     app.register_blueprint(BlueprintBackup)
     app.register_blueprint(BlueprintHealth)
     app.register_blueprint(BlueprintReset)
+    app.register_blueprint(BlueprintIncident)
 
     return app

--- a/blueprints/__init__.py
+++ b/blueprints/__init__.py
@@ -2,7 +2,7 @@
 
 from .backup import blp as BlueprintBackup
 from .health import blp as BlueprintHealth
-from .reset import blp as BlueprintReset
 from .incident import blp as BlueprintIncident
+from .reset import blp as BlueprintReset
 
 __all__ = ['BlueprintBackup', 'BlueprintHealth', 'BlueprintReset', 'BlueprintIncident']

--- a/blueprints/__init__.py
+++ b/blueprints/__init__.py
@@ -4,6 +4,5 @@ from .backup import blp as BlueprintBackup
 from .health import blp as BlueprintHealth
 from .incident import blp as BlueprintIncident
 from .reset import blp as BlueprintReset
-from .incident import blp as BlueprintIncident
 
 __all__ = ['BlueprintBackup', 'BlueprintHealth', 'BlueprintReset', 'BlueprintIncident']

--- a/blueprints/__init__.py
+++ b/blueprints/__init__.py
@@ -3,5 +3,6 @@
 from .backup import blp as BlueprintBackup
 from .health import blp as BlueprintHealth
 from .reset import blp as BlueprintReset
+from .incident import blp as BlueprintIncident
 
-__all__ = ['BlueprintBackup', 'BlueprintHealth', 'BlueprintReset']
+__all__ = ['BlueprintBackup', 'BlueprintHealth', 'BlueprintReset', 'BlueprintIncident']

--- a/blueprints/incident.py
+++ b/blueprints/incident.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import timezone, datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -82,7 +82,7 @@ class RegistryIncident(MethodView):
         history_entry = HistoryEntry(
             incident_id=incident.id,
             client_id=incident.client_id,
-            date=datetime.now(timezone.utc).replace(microsecond=0),
+            date=datetime.now(UTC).replace(microsecond=0),
             action=Action.CREATED,
             description=data.description,
         )

--- a/blueprints/incident.py
+++ b/blueprints/incident.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import timezone, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -82,7 +82,7 @@ class RegistryIncident(MethodView):
         history_entry = HistoryEntry(
             incident_id=incident.id,
             client_id=incident.client_id,
-            date=datetime.now(UTC).replace(microsecond=0),
+            date=datetime.now(timezone.utc).replace(microsecond=0),
             action=Action.CREATED,
             description=data.description,
         )

--- a/blueprints/incident.py
+++ b/blueprints/incident.py
@@ -1,16 +1,25 @@
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import marshmallow.validate
+import marshmallow_dataclass
+from dependency_injector.wiring import Provide
 from flask import Blueprint, Response, request
 from flask.views import MethodView
 from marshmallow import ValidationError
-import marshmallow.validate
-import marshmallow_dataclass
 
-from blueprints.util import class_route
+from blueprints.util import class_route, error_response, json_response, validation_error_response
 from containers import Container
-from models import Incident, Channel
-from typing import Any
+from models import Action, Channel, HistoryEntry, Incident
+from repositories import IncidentRepository, RegistryIncidentError
 
 blp = Blueprint('Incident', __name__)
+
+JSON_VALIDATION_ERROR = 'Request body must be a JSON object.'
+INVALID_UUID_ERROR = 'Invalid UUID format for {field}.'
+
 
 def incident_to_dict(incident: Incident) -> dict[str, Any]:
     return {
@@ -23,20 +32,66 @@ def incident_to_dict(incident: Incident) -> dict[str, Any]:
         'assigned_to': incident.assigned_to,
     }
 
+
 # Incident validation schema
 @dataclass
 class RegistryIncidentBody:
     client_id: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
     name: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=60)})
-    channel: str = field(metadata={'validate': marshmallow.validate.OneOf([Channel.WEB.value, Channel.EMAIL.value, Channel.MOBILE.value])})
+    channel: str = field(
+        metadata={'validate': marshmallow.validate.OneOf([Channel.WEB.value, Channel.EMAIL.value, Channel.MOBILE.value])}
+    )
     reported_by: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
     created_by: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
     description: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=1000)})
     assigned_to: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
 
+
 @class_route(blp, '/api/v1/register/incident')
 class RegistryIncident(MethodView):
     init_every_request = False
 
-    # def get(self) -> Response:
-    #     return Response('Blueprint Works!', status=200)
+    def post(
+        self,
+        incident_repo: IncidentRepository = Provide[Container.incident_repo],
+    ) -> Response:
+        # Validate request body
+        schema = marshmallow_dataclass.class_schema(RegistryIncidentBody)()
+        req_json = request.get_json(silent=True)
+
+        if req_json is None:
+            return error_response(JSON_VALIDATION_ERROR, 400)
+
+        try:
+            data: RegistryIncidentBody = schema.load(req_json)
+        except ValidationError as e:
+            return validation_error_response(e)
+
+        # Create incident
+        incident = Incident(
+            id=str(uuid4()),
+            client_id=data.client_id,
+            name=data.name,
+            channel=Channel(data.channel),
+            reported_by=data.reported_by,
+            created_by=data.created_by,
+            assigned_to=data.assigned_to,
+        )
+
+        # Append history entry
+        history_entry = HistoryEntry(
+            incident_id=incident.id,
+            client_id=incident.client_id,
+            date=datetime.now(UTC).replace(microsecond=0),
+            action=Action.CREATED,
+            description=data.description,
+        )
+
+        # Save incident and history entry
+        try:
+            incident_repo.create(incident)
+            incident_repo.append_history_entry(history_entry)
+        except RegistryIncidentError:
+            return error_response('Error saving the incident', 500)
+
+        return json_response(incident_to_dict(incident), 201)

--- a/blueprints/incident.py
+++ b/blueprints/incident.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from flask import Blueprint, Response, request
+from flask.views import MethodView
+from marshmallow import ValidationError
+import marshmallow.validate
+import marshmallow_dataclass
+
+from blueprints.util import class_route
+from containers import Container
+from models import Incident, Channel
+from typing import Any
+
+blp = Blueprint('Incident', __name__)
+
+def incident_to_dict(incident: Incident) -> dict[str, Any]:
+    return {
+        'id': incident.id,
+        'client_id': incident.client_id,
+        'name': incident.name,
+        'channel': incident.channel.name,
+        'reported_by': incident.reported_by,
+        'created_by': incident.created_by,
+        'assigned_to': incident.assigned_to,
+    }
+
+# Incident validation schema
+@dataclass
+class RegistryIncidentBody:
+    client_id: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
+    name: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=60)})
+    channel: str = field(metadata={'validate': marshmallow.validate.OneOf([Channel.WEB.value, Channel.EMAIL.value, Channel.MOBILE.value])})
+    reported_by: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
+    created_by: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
+    description: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=1000)})
+    assigned_to: str = field(metadata={'validate': marshmallow.validate.Length(min=1, max=50)})
+
+@class_route(blp, '/api/v1/register/incident')
+class RegistryIncident(MethodView):
+    init_every_request = False
+
+    # def get(self) -> Response:
+    #     return Response('Blueprint Works!', status=200)

--- a/blueprints/util.py
+++ b/blueprints/util.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from flask import Blueprint, Response
 from flask.views import MethodView
+from marshmallow import ValidationError
 
 
 def class_route(blueprint: Blueprint, rule: str, **options: Any) -> Callable[[type[MethodView]], type[MethodView]]:  # noqa: ANN401
@@ -16,3 +17,15 @@ def class_route(blueprint: Blueprint, rule: str, **options: Any) -> Callable[[ty
 
 def json_response(data: dict[str, Any] | list[dict[str, Any]], status: int) -> Response:
     return Response(json.dumps(data), status=status, mimetype='application/json')
+
+
+def error_response(msg: str, code: int) -> Response:
+    return json_response({'message': msg, 'code': code}, code)
+
+
+def validation_error_response(err: ValidationError) -> Response:
+    if isinstance(err.messages, dict):
+        msg = ' '.join([f'Invalid value for {k}: {" ".join(v)}' for k, v in err.messages.items()])
+        return error_response(msg, 400)
+
+    raise NotImplementedError('Validation error response for non-dict messages not implemented.')  # pragma: no cover

--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -1,3 +1,4 @@
+from .errors import RegistryIncidentError
 from .incident import IncidentRepository
 
-__all__ = ['IncidentRepository']
+__all__ = ['IncidentRepository', 'RegistryIncidentError']

--- a/repositories/errors.py
+++ b/repositories/errors.py
@@ -1,0 +1,3 @@
+class RegistryIncidentError(Exception):
+    def __init__(self, e: str) -> None:
+        super().__init__(f'Error registering incident: {e}')

--- a/tests/blueprints/test_incident.py
+++ b/tests/blueprints/test_incident.py
@@ -1,0 +1,129 @@
+import json
+from typing import Any, cast
+from unittest.mock import Mock
+
+from faker import Faker
+from unittest_parametrize import ParametrizedTestCase, parametrize
+from werkzeug.test import TestResponse
+
+from app import create_app
+from models import Channel
+from repositories import IncidentRepository, RegistryIncidentError
+
+
+class TestIncident(ParametrizedTestCase):
+    REGISTER_INCIDENT_URL = '/api/v1/register/incident'
+
+    def setUp(self) -> None:
+        self.faker = Faker()
+        self.app = create_app()
+        self.client = self.app.test_client()
+
+    def call_register_incident(self, body: dict[str, Any]) -> TestResponse:
+        return self.client.post(
+            self.REGISTER_INCIDENT_URL,
+            data=json.dumps(body),
+            content_type='application/json',
+        )
+
+    @parametrize(
+        'channel',
+        [
+            (Channel.WEB.value,),
+            (Channel.EMAIL.value,),
+            (Channel.MOBILE.value,),
+        ],
+    )
+    def test_register_incident_success(self, channel: str) -> None:
+        incident_repo_mock = Mock(IncidentRepository)
+        cast(Mock, incident_repo_mock.create).return_value = None
+        cast(Mock, incident_repo_mock.append_history_entry).return_value = None
+
+        payload = {
+            'client_id': str(self.faker.uuid4()),
+            'name': 'Test Incident',
+            'channel': channel,
+            'reported_by': str(self.faker.uuid4()),
+            'created_by': str(self.faker.uuid4()),
+            'description': 'Esto es una incidencia de prueba',
+            'assigned_to': str(self.faker.uuid4()),
+        }
+
+        with self.app.container.incident_repo.override(incident_repo_mock):
+            resp = self.call_register_incident(payload)
+
+        self.assertEqual(resp.status_code, 201)
+        resp_data = json.loads(resp.get_data())
+        self.assertEqual(resp_data['client_id'], payload['client_id'])
+        self.assertEqual(resp_data['name'], payload['name'])
+        self.assertEqual(resp_data['channel'].lower(), payload['channel'].lower())
+        self.assertEqual(resp_data['reported_by'], payload['reported_by'])
+
+    def test_register_incident_invalid_channel(self) -> None:
+        payload = {
+            'client_id': str(self.faker.uuid4()),
+            'name': 'Test Incident',
+            'channel': 'invalid_channel',
+            'reported_by': str(self.faker.uuid4()),
+            'created_by': str(self.faker.uuid4()),
+            'description': 'Esto es una incidencia de prueba',
+            'assigned_to': str(self.faker.uuid4()),
+        }
+
+        resp = self.call_register_incident(payload)
+
+        self.assertEqual(resp.status_code, 400)
+        resp_data = json.loads(resp.get_data())
+        self.assertIn('Invalid value for channel', resp_data['message'])
+
+    @parametrize(
+        'missing_field',
+        [
+            ('client_id',),
+            ('name',),
+            ('channel',),
+            ('reported_by',),
+            ('created_by',),
+            ('description',),
+            ('assigned_to',),
+        ],
+    )
+    def test_register_incident_missing_field(self, missing_field: str) -> None:
+        payload = {
+            'client_id': str(self.faker.uuid4()),
+            'name': 'Test Incident',
+            'channel': Channel.WEB.value,
+            'reported_by': str(self.faker.uuid4()),
+            'created_by': str(self.faker.uuid4()),
+            'description': 'Esto es una incidencia de prueba',
+            'assigned_to': str(self.faker.uuid4()),
+        }
+
+        del payload[missing_field]
+
+        resp = self.call_register_incident(payload)
+
+        self.assertEqual(resp.status_code, 400)
+        resp_data = json.loads(resp.get_data())
+        self.assertIn(f'Invalid value for {missing_field}: Missing data for required field.', resp_data['message'])
+
+    def test_register_incident_repository_error(self) -> None:
+        incident_repo_mock = Mock(IncidentRepository)
+        cast(Mock, incident_repo_mock.create).side_effect = RegistryIncidentError('Error saving the incident')
+
+        payload = {
+            'client_id': str(self.faker.uuid4()),
+            'name': 'Test Incident',
+            'channel': Channel.WEB.value,
+            'reported_by': str(self.faker.uuid4()),
+            'created_by': str(self.faker.uuid4()),
+            'description': 'Esto es una incidencia de prueba',
+            'assigned_to': str(self.faker.uuid4()),
+        }
+
+        with self.app.container.incident_repo.override(incident_repo_mock):
+            resp = self.call_register_incident(payload)
+
+        self.assertEqual(resp.status_code, 500)
+        resp_data = json.loads(resp.get_data())
+        self.assertEqual(resp_data['message'], 'Error saving the incident')


### PR DESCRIPTION
1.  Uso interno.
2.  La lógica de asignación de agente se hace en [microservicio de registro por app](https://github.com/equipo-capibaras/service-registroapp/blob/PF-221-BE-Registro-Incidente-Web/blueprints/incident.py).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new incident registration API endpoint for managing incidents.
	- Added a blueprint for incident management, enhancing application modularity.
	- Implemented structured error handling for incident registration.

- **Bug Fixes**
	- Enhanced error responses for invalid input and missing fields.

- **Tests**
	- Added comprehensive unit tests for the incident registration functionality, covering various scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->