### PR TITLE
:bug: notification when risk was None

### DIFF
--- a/blueprints/incident.py
+++ b/blueprints/incident.py
@@ -267,7 +267,7 @@ class IncidentUpdateRisk(MethodView):
         incident.risk = data.risk
         incident_repo.update(incident)
 
-        if prev_risk != data.risk:
+        if prev_risk != data.risk and prev_risk is not None:
             send_notification(incident.client_id, incident.id, 'incident-risk-updated')
 
         return json_response(incident_to_dict(incident), 200)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the risk update notification logic to ensure notifications are only sent when the risk has changed and the previous risk value is not `None`. 

This change enhances the accuracy of notifications related to risk updates in the incident management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->